### PR TITLE
feat: add navigation after successful file upload in Upload component

### DIFF
--- a/src/views/Upload.jsx
+++ b/src/views/Upload.jsx
@@ -2,8 +2,10 @@ import {useState} from 'react';
 import useForm from '../hooks/formHooks';
 import {useFile} from '../hooks/apiHooks';
 import {useMedia} from '../hooks/apiHooks';
+import {useNavigate} from 'react-router';
 
 const Upload = () => {
+  const navigate = useNavigate();
   const [file, setFile] = useState(null);
   const {postFile} = useFile();
   const {postMedia} = useMedia();
@@ -14,6 +16,7 @@ const Upload = () => {
       console.log('File upload result:', fileResult);
       const mediaResult = await postMedia(fileResult.data, inputs, token);
       console.log('Media result: ' + mediaResult);
+      navigate('/');
     } catch (e) {
       console.log(e.message);
     }


### PR DESCRIPTION
This pull request includes a small change to the `src/views/Upload.jsx` file. The change adds navigation to the home page after a successful media upload.

* [`src/views/Upload.jsx`](diffhunk://#diff-75783f11ac149f87260dbe2b53735c3bb6347b804e50324d126f283ef3ffaa03R5-R8): Imported `useNavigate` from 'react-router' and added a call to `navigate('/')` after the media upload is successful. [[1]](diffhunk://#diff-75783f11ac149f87260dbe2b53735c3bb6347b804e50324d126f283ef3ffaa03R5-R8) [[2]](diffhunk://#diff-75783f11ac149f87260dbe2b53735c3bb6347b804e50324d126f283ef3ffaa03R19)